### PR TITLE
Re-use existing PDO object

### DIFF
--- a/Console/Command/Task/CakeDjjobTask.php
+++ b/Console/Command/Task/CakeDjjobTask.php
@@ -44,16 +44,7 @@ class CakeDjjobTask extends AppShell {
 		$connection = ConnectionManager::getDataSource($this->settings['connection']);
 
 		if ($this->settings['type'] == 'mysql') {
-			DJJob::configure(
-				implode(';', array(
-					"{$this->settings['type']}:host={$connection->config['host']}",
-					"dbname={$connection->config['database']}",
-					"port={$connection->config['port']}",
-				)), array(
-					'mysql_user' => $connection->config['login'],
-					'mysql_pass' => $connection->config['password']
-				)
-			);
+			DJJob::setConnection($connection->getConnection());
 		} else {
 			DJJob::configure(
 				implode(';', array(

--- a/Console/Command/WorkerShell.php
+++ b/Console/Command/WorkerShell.php
@@ -50,16 +50,7 @@ class WorkerShell extends AppShell {
 		$connection = ConnectionManager::getDataSource($this->params['connection']);
 
 		if ($this->params['type'] == 'mysql') {
-			DJJob::configure(
-				implode(';', array(
-					"{$this->params['type']}:host={$connection->config['host']}",
-					"dbname={$connection->config['database']}",
-					"port={$connection->config['port']}",
-				)), array(
-					'mysql_user' => $connection->config['login'],
-					'mysql_pass' => $connection->config['password']
-				)
-			);
+			DJJob::setConnection($connection->getConnection());
 		} else {
 			DJJob::configure(
 				implode(';', array(

--- a/Controller/Component/CakeDjjobComponent.php
+++ b/Controller/Component/CakeDjjobComponent.php
@@ -44,16 +44,7 @@ class CakeDjjobComponent extends Component {
 		$connection = ConnectionManager::getDataSource($this->settings['connection']);
 
 		if ($this->settings['type'] == 'mysql') {
-			DJJob::configure(
-				implode(';', array(
-					"{$this->settings['type']}:host={$connection->config['host']}",
-					"dbname={$connection->config['database']}",
-					"port={$connection->config['port']}",
-				)), array(
-					'mysql_user' => $connection->config['login'],
-					'mysql_pass' => $connection->config['password']
-				)
-			);
+			DJJob::setConnection($connection->getConnection());
 		} else {
 			DJJob::configure(
 				implode(';', array(

--- a/Model/Behavior/CakeDjjobBehavior.php
+++ b/Model/Behavior/CakeDjjobBehavior.php
@@ -43,16 +43,7 @@ class CakeDjjobBehavior extends ModelBehavior {
 		$connection = ConnectionManager::getDataSource($this->settings['connection']);
 
 		if ($this->settings['type'] == 'mysql') {
-			DJJob::configure(
-				implode(';', array(
-					"{$this->settings['type']}:host={$connection->config['host']}",
-					"dbname={$connection->config['database']}",
-					"port={$connection->config['port']}",
-				)), array(
-					'mysql_user' => $connection->config['login'],
-					'mysql_pass' => $connection->config['password']
-				)
-			);
+			DJJob::setConnection($connection->getConnection());
 		} else {
 			DJJob::configure(
 				implode(';', array(


### PR DESCRIPTION
It pains me that CakeDjjob spawns a new connection for it to work. DJJob.php has support for reusing an existing PDO connection:

https://github.com/seatgeek/djjob/blob/master/DJJob.php#L38-39

I notice this because I use xeround.com free MySQL instance for testing and it has a limit of 5 connection. Quite often I run out of connections and its because CakeDjjob is attempting to create a new one.
